### PR TITLE
repos without descriptions do not show 'null'

### DIFF
--- a/GitHubPinner.js
+++ b/GitHubPinner.js
@@ -75,7 +75,7 @@
   }
 
   function getRepo(obj) {
-    var temp = "<div id=\"gp-container-repo\"><a class=\"gp-title\" href=\"" + obj.html_url + "\">" + obj.name + "</a><p class=\"gp-desc\">" + obj.description + "</p><div id=\"gp-stats\">"
+    var temp = "<div id=\"gp-container-repo\"><a class=\"gp-title\" href=\"" + obj.html_url + "\">" + obj.name + "</a><p class=\"gp-desc\">" + (obj.description || '') + "</p><div id=\"gp-stats\">"
     if (obj.language != "" && lang_colors[obj.language] != null) temp += "<p class=\"gp-stat\"><span class=\"gp-lang\" style=\"background-color: " + lang_colors[obj.language]["color"] + ";\"></span>" + obj.language + "</p>"
     if (obj.stargazers_count != 0) temp += "<a class=\"gp-stat gp-link\" href=\"" + obj.html_url + "/stargazers" + "\"><svg class=\"gp-octicon\" height=\"16\" role=\"img\" version=\"1.1\" viewBox=\"0 0 14 16\" width=\"14\"><path fill-rule=\"evenodd\" d=\"M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74z\"></path></svg>" + obj.stargazers_count + "</a>"
     if (obj.forks != 0) temp += "<a class=\"gp-stat gp-link\" href=\"" + obj.html_url + "/network" + "\"><svg class=\"gp-octicon\" height=\"16\" role=\"img\" version=\"1.1\" viewBox=\"0 0 10 16\" width=\"10\"><path fill-rule=\"evenodd\" d=\"M8 1a1.993 1.993 0 0 0-1 3.72V6L5 8 3 6V4.72A1.993 1.993 0 0 0 2 1a1.993 1.993 0 0 0-1 3.72V6.5l3 3v1.78A1.993 1.993 0 0 0 5 15a1.993 1.993 0 0 0 1-3.72V9.5l3-3V4.72A1.993 1.993 0 0 0 8 1zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3 10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3-10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z\"></path></svg>" + obj.forks + "</a>"


### PR DESCRIPTION
Not sure if this is a worthy contribution. I had seen projects on my portfolio page were showing null where the repo description should be. However I think most of the time it makes sense to just add a description to fix this.