### PR TITLE
add "-" to regex in profileName

### DIFF
--- a/GitHubPinner.js
+++ b/GitHubPinner.js
@@ -118,9 +118,9 @@
 
   // MARK: - Helper Functions
   function parseUrl(url) {
-    profile = /^(http|https):\/\/(www.)?github.com(\/)?\/[A-Za-z\d]{1,39}(\/)?$/;
-    repository = /^(http|https):\/\/(www.)?github.com\/[A-Za-z\d]{1,39}\/[A-Za-z\d-]{1,100}(\/)?$/;
-    repositories = /^(http|https):\/\/(www.)?github.com\/[A-Za-z\d]{1,39}\?tab=repositories(\/)?$/;
+    profile = /^(http|https):\/\/(www.)?github.com(\/)?\/[A-Za-z\d-]{1,39}(\/)?$/;
+    repository = /^(http|https):\/\/(www.)?github.com\/[A-Za-z\d-]{1,39}\/[A-Za-z\d-]{1,100}(\/)?$/;
+    repositories = /^(http|https):\/\/(www.)?github.com\/[A-Za-z\d-]{1,39}\?tab=repositories(\/)?$/;
     if (profile.test(url)) {
       // profile
       var profileName = url.replace(/^(http|https):\/\/(www.)?github.com(\/)?/g, "").replace(/\/$/, "")
@@ -128,7 +128,7 @@
     } else if (repository.test(url)) {
       // repository
       var profileName = url.replace(/^(http|https):\/\/(www.)?github.com(\/)?/g, "").replace(/\/.*(\/)?$/, "")
-      var repositoryName = url.replace(/^(http|https):\/\/(www.)?github.com\/[A-Za-z\d]{1,39}\//g, "").replace(/\/$/, "")
+      var repositoryName = url.replace(/^(http|https):\/\/(www.)?github.com\/[A-Za-z\d-]{1,39}\//g, "").replace(/\/$/, "")
       return {"URL" : "https://api.github.com/repos/" + profileName + "/" + repositoryName, "TYPE": types["REPO"] }
     } else if (repositories.test(url)) {
       // repositories


### PR DESCRIPTION
Before this change usernames or organization names with a hyphen would fail to render. For example a repository card would not show for https://github.com/glade-software/glade-element because glade-software has a hyphen in it, this PR fixes that case.